### PR TITLE
apply 100% height to html+body to make canvas elements visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
 	<script src="js/recorderjs/recorder.js"></script>
 	<script src="js/main.js"></script>
 	<style>
-	html { overflow: hidden; }
+	html { overflow: hidden; height: 100%; }
 	body { 
 		font: 14pt Arial, sans-serif; 
 		background: lightgrey;
 		display: flex;
 		flex-direction: column;
-		height: 100vh;
+		height: 100%;
 		width: 100%;
 		margin: 0 0;
 	}


### PR DESCRIPTION
I wasn't seeing the canvas elements at all in my version of chrome until I tweaked the css a bit - see http://stackoverflow.com/questions/17386199/height-100-not-working
