### PR TITLE
changes as per google new policy for autoplay

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,13 @@ function doneEncoding( blob ) {
 }
 
 function toggleRecording( e ) {
+    // Changes as per the google autoplay-policy-changes
+    // ref: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio
+    if(audioContext.state !== "running"){
+        audioContext.resume().then(() => {
+            console.log('Playback resumed successfully');
+        });
+    }
     if (e.classList.contains("recording")) {
         // stop recording
         audioRecorder.stop();


### PR DESCRIPTION
The demo was not running my laptop, so I wondered it is happening. So, I checked it on my friend's laptop also. After looking for the solution, I get to know that Google has changed its policies for autoplay web audio. Then, I made the changes locally as per [https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio) and it's working fine everywhere now. I thought it will help someone save a few hours, hence creating a PR for the same.