### PR TITLE
Moved initialization of audioContext inside gotStream() funciton

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,7 +15,6 @@
 
 window.AudioContext = window.AudioContext || window.webkitAudioContext;
 
-var audioContext = new AudioContext();
 var audioInput = null,
     realAudioInput = null,
     inputPoint = null,
@@ -136,6 +135,8 @@ function toggleMono() {
 }
 
 function gotStream(stream) {
+    window.audioContext = new AudioContext();
+
     inputPoint = audioContext.createGain();
 
     // Create an AudioNode from the stream.


### PR DESCRIPTION
Global initialization of AudioContext() is forbidden by latest Chrome
and generates a warning in the console.